### PR TITLE
add support for incident client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     rev: 5.1.4
     hooks:
       - id: isort
-        language_version: python3.7
+        language_version: python3.8
         args: [--multi-line=3,--trailing-comma,--force-grid-wrap=0,--use-parentheses,--line-length=88,--ensure-newline-before-comments]
   - repo: https://github.com/ambv/black
     rev: 20.8b1
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
 
   - repo: git@github.com:humitos/mirrors-autoflake.git
     rev: v1.3

--- a/lightctl/client/incident_client.py
+++ b/lightctl/client/incident_client.py
@@ -1,0 +1,23 @@
+import logging
+import urllib.parse
+
+from lightctl.client.base_client import BaseClient
+
+logger = logging.getLogger(__name__)
+
+
+class IncidentClient(BaseClient):
+    @property
+    def incident_url(self):
+        return urllib.parse.urljoin(
+            self.url_base, f"/api/v0/topologies/lightuplongrunworkend/incidents"
+        )
+
+    def get_incidents(self, rule_id, start_ts, end_ts):
+        assert rule_id is not None
+        assert start_ts is not None
+        assert end_ts is not None
+        assert start_ts < end_ts
+
+        url = self.incident_url + f"?{start_ts=}&{end_ts=}&filter_uuids={rule_id}"
+        return self.get(url).get("data")

--- a/lightctl/client/metric_client.py
+++ b/lightctl/client/metric_client.py
@@ -23,7 +23,7 @@ class MetricClient(BaseClient):
     def get_metric_by_name(self, name):
         metrics = self.list_metrics()
         for metric in metrics:
-            if metric["name"] == name:
+            if metric["metadata"]["name"] == name:
                 return metric
         return None
 

--- a/lightctl/client/rule_client.py
+++ b/lightctl/client/rule_client.py
@@ -1,5 +1,6 @@
 import logging
 import urllib.parse
+from typing import List, Optional
 
 from lightctl.client.base_client import BaseClient
 from lightctl.config import API_VERSION
@@ -33,3 +34,18 @@ class RuleClient(BaseClient):
 
     def delete_rule(self, id):
         self.delete(self.rules_url, id)
+
+    def get_rules_by_metric(self, metric_uuid) -> List[dict]:
+        rules_in_metric = []
+
+        rules = self.list_rules()
+        for rule in rules:
+            if metric_uuid in rule["config"]["metrics"]:
+                rules_in_metric.append(rule)
+        return rules_in_metric
+
+    def last_processed_timestamp(self, id) -> Optional[float]:
+        rule = self.get_rule(id)
+        if rule is None:
+            return None
+        return rule["status"]["lastSampleTs"]


### PR DESCRIPTION
This is needed to support runtime checks on the health of a metric - see: http://bit.ly/lightctl-api-yaml for more information. 

This PR adds support for Incident Service (This is still in v0 API and needs to be migrated)

Tested manually using the script in the doc above.