### PR TITLE
source: add a command to trigger a source profiler/metric-collector run

### DIFF
--- a/lightctl/client/source_client.py
+++ b/lightctl/client/source_client.py
@@ -64,7 +64,11 @@ class SourceClient(BaseClient):
         return self.put(url, data)
 
     def trigger_source(self, id):
-        url = urllib.parse.join(
+        source = self.get_source(id)
+        if not source["config"].get("triggered", {}).get("enabled"):
+            return {"error": "source is not configured for triggers"}
+
+        url = urllib.parse.urljoin(
             self.url_base, f"/api/{API_VERSION}/sources/{id}/trigger"
         )
-        return self.put(url)
+        return self.put(url, data={})

--- a/lightctl/command/source_command.py
+++ b/lightctl/command/source_command.py
@@ -40,10 +40,23 @@ def clone(context_obj, id):
     res = source_client.get_source(id)
     if not res:
         context_obj.printer.print({"error": "not found"})
+        return
 
     res["metadata"].pop("uuid")
     res["metadata"]["name"] += "_Clone"
     res = source_client.create_source(res)
+    context_obj.printer.print(res)
+
+
+@source.command()
+@click.argument("id")
+@click.pass_obj
+def trigger(context_obj, id):
+    res = source_client.get_source(id)
+    if not res:
+        context_obj.printer.print({"error": "not found"})
+        return
+    res = source_client.trigger_source(id)
     context_obj.printer.print(res)
 
 


### PR DESCRIPTION
Add a CLI command to trigger a source. 

Example usage:

`lightctl source trigger 1e38aba1-7a24-4ad9-8f6a-2f13907ad3fb`