### PR TITLE
incident: remove topologies from url path

### DIFF
--- a/lightctl/client/incident_client.py
+++ b/lightctl/client/incident_client.py
@@ -10,9 +10,7 @@ logger = logging.getLogger(__name__)
 class IncidentClient(BaseClient):
     @property
     def incident_url(self) -> str:
-        return urllib.parse.urljoin(
-            self.url_base, f"/api/v0/topologies/lightuplongrunworkend/incidents"
-        )
+        return urllib.parse.urljoin(self.url_base, f"/api/v0/incidents")
 
     def get_incidents(self, monitor_id: str, start_ts: int, end_ts: int) -> Dict:
         assert monitor_id is not None


### PR DESCRIPTION
https://github.com/lightup-data/lumen/pull/6301 removes topologies from the URL. This PR makes the same changes for lightctl