### PR TITLE
Fix broken requirements to enable ship.sh to work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-click==7.0
+click==8.1
+MarkupSafe==2.0.1
 pyyaml==5.4
 requests==2.22.0
 s3pypi==0.11.0


### PR DESCRIPTION
ship.sh was not working and leading to this error (caused by deprecation of the unicode function in MarkupSafe. Downgrading to an older version of MarkupSafe till we can upgrade s3pypi to the next version (which is incompatible with the previous version).

```
Uploading package... 
Traceback (most recent call last):
  File "/Users/rajiv/work/lightctl/.lightctl-venv/bin/s3pypi", line 5, in <module>
    from s3pypi.__main__ import main
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/s3pypi/__main__.py", line 9, in <module>
    from s3pypi.package import Package
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/s3pypi/package.py", line 9, in <module>
    from jinja2 import Environment, PackageLoader
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/Users/rajiv/work/lightctl/.lightctl-venv/lib/python3.8/site-packages/markupsafe/__init__.py)
```