### PR TITLE
lightctl: Add app user detail patch in lightctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.idea/

--- a/integration_tests/client/test_user_client.py
+++ b/integration_tests/client/test_user_client.py
@@ -75,7 +75,6 @@ class TestUserClient:
 
     def test_update_app_user_detail(
         self,
-        fixture_workspace: Dict,
         fixture_user_client: UserClient,
     ):
         user_id = TEST_EMAIL_ADDRESS

--- a/integration_tests/client/test_user_client.py
+++ b/integration_tests/client/test_user_client.py
@@ -4,6 +4,7 @@ from typing import Dict
 import pytest
 
 from lightctl.client.user_client import UserClient
+from lightctl.util import LightupException
 
 TEST_EMAIL_ADDRESS = "fillmein+{}@xyz.com"
 
@@ -78,14 +79,18 @@ class TestUserClient:
         fixture_user_client: UserClient,
     ):
         user_id = TEST_EMAIL_ADDRESS
+        try:
+            fixture_user_client.delete_app_user(user_id)
+        except LightupException:
+            pass
         fixture_user_client.add_app_user(user_id, "app_viewer")
         app_user = fixture_user_client.get_app_user(user_id)
-        assert "expiration_timestamp" not in app_user
+        assert app_user["expiration_timestamp"] is None
 
-        fixture_user_client.update_app_user_detail(user_id, {"expirationTimestamp": 123456789})
+        fixture_user_client.update_app_user_detail(user_id, {"expirationTimestamp": 1704067200})
 
         app_user = fixture_user_client.get_app_user(user_id)
-        assert app_user["expiration_timestamp"] == 123456789
+        assert app_user["expiration_timestamp"] == 1704067200
 
         # clean up
         fixture_user_client.delete_app_user(user_id)

--- a/integration_tests/client/test_user_client.py
+++ b/integration_tests/client/test_user_client.py
@@ -7,6 +7,7 @@ from lightctl.client.user_client import UserClient
 
 TEST_EMAIL_ADDRESS = "fillmein+{}@xyz.com"
 
+
 class TestUserClient:
     @pytest.fixture
     def fixture_user_client(self) -> UserClient:
@@ -71,3 +72,21 @@ class TestUserClient:
 
         res = fixture_user_client.list_users(workspace_id)
         assert len(res) == 0
+
+    def test_update_app_user_detail(
+        self,
+        fixture_workspace: Dict,
+        fixture_user_client: UserClient,
+    ):
+        user_id = TEST_EMAIL_ADDRESS
+        fixture_user_client.add_app_user(user_id, "app_viewer")
+        app_user = fixture_user_client.get_app_user(user_id)
+        assert "expiration_timestamp" not in app_user
+
+        fixture_user_client.update_app_user_detail(user_id, {"expirationTimestamp": 123456789})
+
+        app_user = fixture_user_client.get_app_user(user_id)
+        assert app_user["expiration_timestamp"] == 123456789
+
+        # clean up
+        fixture_user_client.delete_app_user(user_id)

--- a/lightctl/client/user_client.py
+++ b/lightctl/client/user_client.py
@@ -44,6 +44,20 @@ class UserClient(BaseClient):
         res = self.post(url, payload)
         return res
 
+    def update_app_user_detail(self, user_id: str, payload: dict):
+        """
+        Update a user's detail in the app
+
+        Args:
+            user_id (str): User id (email) of user to be updated
+            payload (dict): Properties to be modified
+        Returns:
+            dict: A user object
+        """
+        quoted_user = urllib.parse.quote_plus(user_id)
+        url = urllib.parse.urljoin(self.app_users_url(), quoted_user)
+        return self.patch(url, payload)
+
     def update_app_user_role(self, user_id: str, role: str):
         """
         Update a user's role in the app
@@ -51,14 +65,11 @@ class UserClient(BaseClient):
         Args:
             user_id (str): User id (email) of user to be updated
             role (str): New role of user. Legal roles are "app_admin", "app_editor", "app_viewer"
-        Returns: 
+        Returns:
             dict: A user object
         """
         assert role in ["app_admin", "app_editor", "app_viewer"]
-        quoted_user = urllib.parse.quote_plus(user_id)
-        url = urllib.parse.urljoin(self.app_users_url(), quoted_user)
-        payload = {"role": role}
-        return self.patch(url, payload)
+        return self.update_app_user_detail(user_id, {"role": role})
 
     def delete_app_user(self, user_id: str):
         """
@@ -147,7 +158,7 @@ class UserClient(BaseClient):
             workspace_id (str): Workspace id
             user_id (str): User id (email) of user to be removed
             role (str): New role of user. Legal roles are "viewer", "editor", "admin", and "observer" 
-        Returns: 
+        Returns:
             dict: A user object with role set to the user's role in the workspace
         """
         quoted_user = urllib.parse.quote_plus(user_id)


### PR DESCRIPTION
Add app user detail patch in lightctl

https://lightup.atlassian.net/browse/FT-229

TEST:
Added a new integration test to cover this. Integration test runs successfully against stage:
```
pytest -k "test_update_app_user_detail" -vvv
======================================================================================= test session starts =======================================================================================
platform linux -- Python 3.10.12, pytest-7.1.3, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
collected 5 items / 4 deselected / 1 selected                                                                                                                                                     

integration_tests/client/test_user_client.py::TestUserClient::test_update_app_user_detail PASSED                                                                                            [100%]

================================================================================= 1 passed, 4 deselected in 1.78s =================================================================================
```