### PR TITLE
user client: rename user id to username

### DIFF
--- a/lightctl/client/user_client.py
+++ b/lightctl/client/user_client.py
@@ -20,6 +20,7 @@ class UserClient(BaseClient):
         uc.add_user_to_workspace(workspace_to_update["uuid"], "user@hello.com", "editor")
 
     """
+
     def app_users_url(self) -> str:
         """
         Returns:
@@ -27,76 +28,76 @@ class UserClient(BaseClient):
         """
         return urllib.parse.urljoin(self.url_base, "/api/v0/users/")
 
-    def add_app_user(self, user_id: str, role: str) -> Dict:
+    def add_app_user(self, username: str, role: str) -> Dict:
         """
         Add a user to the app
 
         Args:
-            user_id (str): User id (email) of user to be added to workspace
+            username (str): Username (email) of user to be added to workspace
             role (str): Role of user when added to app. Legal roles are "app_admin", "app_editor", "app_viewer"
 
-        Returns: 
+        Returns:
             dict: A user object
         """
         assert role in ["app_admin", "app_editor", "app_viewer"]
         url = self.app_users_url()
-        payload = {"email": user_id, "app_role": role}
+        payload = {"email": username, "app_role": role}
         res = self.post(url, payload)
         return res
 
-    def update_app_user_detail(self, user_id: str, payload: dict):
+    def update_app_user_detail(self, username: str, payload: dict):
         """
         Update a user's detail in the app
 
         Args:
-            user_id (str): User id (email) of user to be updated
+            username (str): Username (email) of user to be updated
             payload (dict): Properties to be modified
         Returns:
             dict: A user object
         """
-        quoted_user = urllib.parse.quote_plus(user_id)
+        quoted_user = urllib.parse.quote_plus(username)
         url = urllib.parse.urljoin(self.app_users_url(), quoted_user)
         return self.patch(url, payload)
 
-    def update_app_user_role(self, user_id: str, role: str):
+    def update_app_user_role(self, username: str, role: str):
         """
         Update a user's role in the app
 
         Args:
-            user_id (str): User id (email) of user to be updated
+            username (str): Username (email) of user to be updated
             role (str): New role of user. Legal roles are "app_admin", "app_editor", "app_viewer"
         Returns:
             dict: A user object
         """
         assert role in ["app_admin", "app_editor", "app_viewer"]
-        return self.update_app_user_detail(user_id, {"role": role})
+        return self.update_app_user_detail(username, {"role": role})
 
-    def delete_app_user(self, user_id: str):
+    def delete_app_user(self, username: str):
         """
         Remove a user from the app
 
         Args:
-            user_id (str): User id (email) of user to be removed
+            username (str): Username (email) of user to be removed
 
-        Returns: 
+        Returns:
             ??
         """
-        quoted_user = urllib.parse.quote_plus(user_id)
+        quoted_user = urllib.parse.quote_plus(username)
         url = self.app_users_url()
         res = self.delete(url, quoted_user, force=True)
         return res
 
-    def get_app_user(self, user_id: str):
+    def get_app_user(self, username: str):
         """
-        Get an app user by user_id
+        Get an app user by username
 
         Args:
-            user_id (str): User id (email) of user to be returned
+            username (str): Username (email) of user to be returned
 
-        Returns: 
+        Returns:
             dict: A user object
         """
-        quoted_user = urllib.parse.quote_plus(user_id)
+        quoted_user = urllib.parse.quote_plus(username)
         url = urllib.parse.urljoin(self.app_users_url(), quoted_user)
         return self.get(url)
 
@@ -120,48 +121,50 @@ class UserClient(BaseClient):
         """
         return urllib.parse.urljoin(self.url_base, f"/api/v0/ws/{workspace_id}/users/")
 
-    def add_user_to_workspace(self, workspace_id: str, user_id: str, role: str) -> Dict:
+    def add_user_to_workspace(
+        self, workspace_id: str, username: str, role: str
+    ) -> Dict:
         """
         Add a user to a workspace
 
         Args:
             workspace_id (str): Workspace id
-            user_id (str): User id (email) of user to be added to workspace
-            role (str): Role of user when added to workspace. Legal roles are "viewer", "editor", "admin", and "observer" 
+            username (str): Username (email) of user to be added to workspace
+            role (str): Role of user when added to workspace. Legal roles are "viewer", "editor", "admin", and "observer"
 
-        Returns: 
+        Returns:
             dict: A user object with role set to the user's role in the workspace
         """
         url = self.users_url(workspace_id)
-        payload = {"email": user_id, "role": role}
+        payload = {"email": username, "role": role}
         res = self.post(url, payload)
         return res
 
-    def remove_user_from_workspace(self, workspace_id: str, user_id: str) -> Dict:
+    def remove_user_from_workspace(self, workspace_id: str, username: str) -> Dict:
         """
         Remove user from a workspace
 
         Args:
             workspace_id (str): Workspace id
-            user_id (str): User id (email) of user to be removed
+            username (str): Username (email) of user to be removed
 
         """
         url = self.users_url(workspace_id)
-        quoted_user = urllib.parse.quote_plus(user_id)
+        quoted_user = urllib.parse.quote_plus(username)
         return self.delete(url, quoted_user, force=True)
 
-    def update_user_role(self, workspace_id: str, user_id: str, role: str):
+    def update_user_role(self, workspace_id: str, username: str, role: str):
         """
         Update a user's role in a workspace
 
         Args:
             workspace_id (str): Workspace id
-            user_id (str): User id (email) of user to be removed
-            role (str): New role of user. Legal roles are "viewer", "editor", "admin", and "observer" 
+            username (str): Username (email) of user to be removed
+            role (str): New role of user. Legal roles are "viewer", "editor", "admin", and "observer"
         Returns:
             dict: A user object with role set to the user's role in the workspace
         """
-        quoted_user = urllib.parse.quote_plus(user_id)
+        quoted_user = urllib.parse.quote_plus(username)
         url = urllib.parse.urljoin(self.users_url(workspace_id), quoted_user)
         payload = {"role": role}
         return self.patch(url, payload)


### PR DESCRIPTION
Username based API endpoints will be deprecated shortly and replaced by user_id based endpoints. This PR renames existing functions to use username. This will be followed by another set of function that will add support for user_id based endpoints.