### PR TITLE
lightctl: reformat based on pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        language_version: python3.9.13
+        language_version: python3.9.16
         args: [--multi-line=3,--trailing-comma,--force-grid-wrap=0,--use-parentheses,--line-length=88,--ensure-newline-before-comments]
 
   - repo: https://github.com/asottile/pyupgrade
@@ -29,4 +29,4 @@ repos:
     rev: 23.10.1
     hooks:
       - id: black
-        language_version: python3.9.13
+        language_version: python3.9.16

--- a/bin/lightctl
+++ b/bin/lightctl
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import sys
 
 import click

--- a/dev.sh
+++ b/dev.sh
@@ -10,13 +10,13 @@ cd "${REPO_DIR}" || exit
 deactivate || true
 
 # set python dev env
-python3 -m venv .lightctl-venv
+python -m venv .lightctl-venv
 source .lightctl-venv/bin/activate
-pip3 install --upgrade pip
-pip3 install -r requirements.txt
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 
 # install pre-commit, use it Black as in .pre-commit-config.yaml
-pip3 install pre-commit
+python -m pip install pre-commit
 pre-commit install
 
 export PYTHONPATH=$(pwd):$PYTHONPATH

--- a/integration_tests/client/test_source_client.py
+++ b/integration_tests/client/test_source_client.py
@@ -1,6 +1,5 @@
 import os
 import uuid
-from typing import Dict
 
 import pytest
 
@@ -14,8 +13,8 @@ class TestSourceClient:
         return source_client
 
     @staticmethod
-    def get_source_dict() -> Dict:
-        source_dict: Dict = {
+    def get_source_dict() -> dict:
+        source_dict: dict = {
             "metadata": {"name": f"Lightctl Test Databricks - {uuid.uuid4()}"},
             "config": {
                 "connection": {
@@ -35,7 +34,7 @@ class TestSourceClient:
 
     def test_source_create_list_delete(
         self,
-        fixture_workspace: Dict,
+        fixture_workspace: dict,
         fixture_source_client: SourceClient,
     ):
         workspace_id = fixture_workspace["uuid"]

--- a/integration_tests/client/test_user_client.py
+++ b/integration_tests/client/test_user_client.py
@@ -1,5 +1,4 @@
 import uuid
-from typing import Dict
 
 import pytest
 
@@ -36,7 +35,7 @@ class TestUserClient:
 
     def test_add_update_remove_user(
         self,
-        fixture_workspace: Dict,
+        fixture_workspace: dict,
         fixture_user_client: UserClient,
         fixture_user: str,
     ):
@@ -87,7 +86,9 @@ class TestUserClient:
         app_user = fixture_user_client.get_app_user(user_id)
         assert app_user["expiration_timestamp"] is None
 
-        fixture_user_client.update_app_user_detail(user_id, {"expirationTimestamp": 1704067200})
+        fixture_user_client.update_app_user_detail(
+            user_id, {"expirationTimestamp": 1704067200}
+        )
 
         app_user = fixture_user_client.get_app_user(user_id)
         assert app_user["expiration_timestamp"] == 1704067200

--- a/lightctl/client/base_client.py
+++ b/lightctl/client/base_client.py
@@ -5,7 +5,7 @@ import logging
 import os.path
 import urllib.parse
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import requests
 
@@ -52,12 +52,12 @@ class BaseClient:
 
         self.access_token: Optional[str] = self._get_cached_access_token()
 
-    def get(self, endpoint: str) -> Dict:
+    def get(self, endpoint: str) -> dict:
         r = self._get(endpoint)
         check_status_code(r, 200)
         return json.loads(r.text)
 
-    def post(self, endpoint: str, data: Dict, expected_status: int = 201) -> Dict:
+    def post(self, endpoint: str, data: dict, expected_status: int = 201) -> dict:
         data = json.dumps(data, default=_json_serial)
         headers = get_headers()
         r = self._post(endpoint, data=data, headers=headers)
@@ -73,14 +73,14 @@ class BaseClient:
         check_status_code(r, 204)
         return {"id": id}
 
-    def put(self, endpoint: str, data: Dict, force: bool = False):
+    def put(self, endpoint: str, data: dict, force: bool = False):
         data = json.dumps(data, default=_json_serial)
         headers = get_headers(force)
         r = self._put(endpoint, data=data, headers=headers)
         check_status_code(r, 200)
         return json.loads(r.text)
 
-    def patch(self, endpoint: str, data: Dict, force: bool = False):
+    def patch(self, endpoint: str, data: dict, force: bool = False):
         data = json.dumps(data, default=_json_serial)
         headers = get_headers(force)
         r = self._patch(endpoint, data=data, headers=headers)
@@ -132,7 +132,7 @@ class BaseClient:
     def _get_cached_access_token() -> Optional[str]:
         if not Path(ACCESS_TOKEN_CACHE_FILE_PATH).exists():
             return None
-        with open(ACCESS_TOKEN_CACHE_FILE_PATH, "r") as f:
+        with open(ACCESS_TOKEN_CACHE_FILE_PATH) as f:
             return f.read()
 
     @staticmethod

--- a/lightctl/client/healthz_client.py
+++ b/lightctl/client/healthz_client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict
 
 from lightctl.client.base_client import BaseClient
 
@@ -16,15 +15,16 @@ class HealthzClient(BaseClient):
         hc.get_healthz_info()
 
     """
+
     @property
     def healthz_url(self) -> str:
         """
         Returns:
            str: The healthz endpoint
         """
-        return urllib.parse.urljoin(self.url_base, f"/api/v0/healthz/")
+        return urllib.parse.urljoin(self.url_base, "/api/v0/healthz/")
 
-    def get_healthz_info(self) -> Dict:
+    def get_healthz_info(self) -> dict:
         """
         Get healthz info
 

--- a/lightctl/client/incident_client.py
+++ b/lightctl/client/incident_client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Dict, Optional
+from typing import Optional
 from uuid import UUID
 
 from lightctl.client.base_client import BaseClient
@@ -31,6 +31,7 @@ class IncidentClient(BaseClient):
                         num_incidents = len(incidents)
                         print("Workspace {workspace['name']} Metric {metric['metatdata']['name']} Monitor {monitor['metadata']['name']} {num_incidents} Incidents)
     """
+
     INCIDENT_STATUS_MAP = {
         "unviewed": 1,
         "viewed": 2,
@@ -58,7 +59,7 @@ class IncidentClient(BaseClient):
         metric_id: Optional[str] = None,
         source_id: Optional[str] = None,
         status: Optional[str] = None,
-    ) -> Dict:
+    ) -> dict:
         """
         Args:
             workspace_id (str): Id of workspace
@@ -92,7 +93,7 @@ class IncidentClient(BaseClient):
         )
         return self.get(url).get("data")
 
-    def update_incident_status(self, workspace_id: str, id: str, status: str) -> Dict:
+    def update_incident_status(self, workspace_id: str, id: str, status: str) -> dict:
         incident_status = self.INCIDENT_STATUS_MAP.get(status)
         assert incident_status is not None, f"invalid incident status '{status}'"
         url = urllib.parse.urljoin(self.incidents_url(workspace_id), f"{id}")
@@ -100,7 +101,7 @@ class IncidentClient(BaseClient):
 
     def update_incident_validation(
         self, workspace_id: str, id: str, status: str
-    ) -> Dict:
+    ) -> dict:
         validation_status = status.lower()
         assert validation_status in [
             "running",

--- a/lightctl/client/metric_client.py
+++ b/lightctl/client/metric_client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict, List
 from uuid import UUID
 
 from lightctl.client.base_client import BaseClient
@@ -23,6 +22,7 @@ class MetricClient(BaseClient):
             for metric in metric_list:
                 print("Workspace {workspace["name"]} Metric {metric["metatdata"]["name"]}
     """
+
     def metrics_url(self, workspace_id: str) -> str:
         """
         Returns:
@@ -32,7 +32,7 @@ class MetricClient(BaseClient):
             self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/metrics/"
         )
 
-    def list_metrics(self, workspace_id: str) -> List[Dict]:
+    def list_metrics(self, workspace_id: str) -> list[dict]:
         """
         Get all metrics in the workspace
 
@@ -44,7 +44,7 @@ class MetricClient(BaseClient):
         """
         return self.get(self.metrics_url(workspace_id))
 
-    def get_metric(self, workspace_id: str, id: UUID) -> Dict:
+    def get_metric(self, workspace_id: str, id: UUID) -> dict:
         """
         Get a metric by its uuid
 
@@ -58,7 +58,7 @@ class MetricClient(BaseClient):
         url = urllib.parse.urljoin(self.metrics_url(workspace_id), f"{id}")
         return self.get(url)
 
-    def get_metric_by_name(self, workspace_id: str, name: str) -> List[Dict]:
+    def get_metric_by_name(self, workspace_id: str, name: str) -> list[dict]:
         """
         Get a metric by its name
 
@@ -72,7 +72,7 @@ class MetricClient(BaseClient):
         url = urllib.parse.urljoin(self.metrics_url(workspace_id), f"?name={name}")
         return self.get(url)
 
-    def create_metric(self, workspace_id: str, data: Dict) -> Dict:
+    def create_metric(self, workspace_id: str, data: dict) -> dict:
         """
         Create a metric
 
@@ -86,8 +86,8 @@ class MetricClient(BaseClient):
         return self.post(self.metrics_url(workspace_id), data)
 
     def update_metric(
-        self, workspace_id: str, id: UUID, data: Dict, force: bool = False
-    ) -> Dict:
+        self, workspace_id: str, id: UUID, data: dict, force: bool = False
+    ) -> dict:
         """
         Update a metric
 

--- a/lightctl/client/monitor_client.py
+++ b/lightctl/client/monitor_client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Dict, List, Optional
+from typing import Optional
 from uuid import UUID
 
 from lightctl.client.base_client import BaseClient
@@ -27,6 +27,7 @@ class MonitorClient(BaseClient):
                 for monitor in monitor_list:
                     print("Workspace {workspace["name"]} Metric {metric["metatdata"]["name"]} Monitor {monitor["metadata"]["name"]}
     """
+
     def monitors_url(self, workspace_id: str) -> str:
         """
         Returns:
@@ -36,7 +37,7 @@ class MonitorClient(BaseClient):
             self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/monitors/"
         )
 
-    def list_monitors(self, workspace_id: str) -> List[Dict]:
+    def list_monitors(self, workspace_id: str) -> list[dict]:
         """
         Get all monitors in the workspace
 
@@ -49,7 +50,7 @@ class MonitorClient(BaseClient):
         res = self.get(self.monitors_url(workspace_id))
         return res.get("data", [])
 
-    def get_monitor(self, workspace_id: str, id: UUID) -> Dict:
+    def get_monitor(self, workspace_id: str, id: UUID) -> dict:
         """
         Get a monitor by its uuid
 
@@ -64,7 +65,7 @@ class MonitorClient(BaseClient):
         monitor = self.get(url)
         return monitor
 
-    def get_monitor_by_name(self, workspace_id: str, name: str) -> List[Dict]:
+    def get_monitor_by_name(self, workspace_id: str, name: str) -> list[dict]:
         """
         Get a monitor by its name
 
@@ -79,7 +80,7 @@ class MonitorClient(BaseClient):
         # name is not unique
         return self.get(url)
 
-    def create_monitor(self, workspace_id: str, data: Dict) -> Dict:
+    def create_monitor(self, workspace_id: str, data: dict) -> dict:
         """
         Create a monitor
 
@@ -92,7 +93,7 @@ class MonitorClient(BaseClient):
         """
         return self.post(self.monitors_url(workspace_id), data)
 
-    def update_monitor(self, workspace_id: str, id: UUID, data: Dict) -> Dict:
+    def update_monitor(self, workspace_id: str, id: UUID, data: dict) -> dict:
         """
         Update a monnitor
 
@@ -120,7 +121,7 @@ class MonitorClient(BaseClient):
 
     def get_monitors_by_metric(
         self, workspace_id: str, metric_uuid: UUID
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Get all monitors on a metric
 

--- a/lightctl/client/profiler_client.py
+++ b/lightctl/client/profiler_client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Dict, List, Optional
+from typing import Optional
 
 from lightctl.client.base_client import BaseClient
 from lightctl.config import API_VERSION
@@ -13,6 +13,7 @@ class ProfilerClient(BaseClient):
     Helper functions for acessing table configuration
 
     """
+
     def profiler_base_url(self, workspace_id: str, source_uuid) -> str:
         """
         Returns:
@@ -48,7 +49,7 @@ class ProfilerClient(BaseClient):
 
     def get_schema_profiler_config(
         self, workspace_id: str, source_uuid: str, schema_uuid: str
-    ) -> Dict:
+    ) -> dict:
         """
         Get schema configuration
 
@@ -69,8 +70,8 @@ class ProfilerClient(BaseClient):
         return self.get(url)
 
     def update_schema_profiler_config(
-        self, workspace_id: str, source_uuid: str, schema_uuid: str, data: Dict
-    ) -> Dict:
+        self, workspace_id: str, source_uuid: str, schema_uuid: str, data: dict
+    ) -> dict:
         """
         Update configuration for a schema in a datasource
 
@@ -122,7 +123,7 @@ class ProfilerClient(BaseClient):
 
     def get_table_profiler_config(
         self, workspace_id: str, source_uuid: str, table_uuid: str
-    ) -> Dict:
+    ) -> dict:
         """
         Get table configuration
 
@@ -143,8 +144,8 @@ class ProfilerClient(BaseClient):
         return self.get(url)
 
     def update_table_profiler_config(
-        self, workspace_id: str, source_uuid: str, table_uuid: str, data: Dict
-    ) -> Dict:
+        self, workspace_id: str, source_uuid: str, table_uuid: str, data: dict
+    ) -> dict:
         """
         Update configuration for a table in a datasource
 
@@ -191,7 +192,7 @@ class ProfilerClient(BaseClient):
 
     def get_column_profiler_config(
         self, workspace_id: str, source_uuid: str, table_uuid: str, column_uuid: str
-    ) -> Dict:
+    ) -> dict:
         """
         Get column configuration
 
@@ -217,8 +218,8 @@ class ProfilerClient(BaseClient):
         source_uuid: str,
         table_uuid: str,
         column_uuid: str,
-        data: Dict,
-    ) -> Dict:
+        data: dict,
+    ) -> dict:
         """
         Update configuration for a column
 
@@ -237,7 +238,7 @@ class ProfilerClient(BaseClient):
         )
         return self.put(url, data)
 
-    def list_schemas(self, workspace_id: str, source_uuid: str) -> List[Dict]:
+    def list_schemas(self, workspace_id: str, source_uuid: str) -> list[dict]:
         """
         Get all schemas in a workspace and specified datasource
 
@@ -255,7 +256,7 @@ class ProfilerClient(BaseClient):
 
     def list_tables(
         self, workspace_id: str, source_uuid: str, schema_uuid: Optional[str] = None
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Get all tables in a datasource
 
@@ -278,7 +279,7 @@ class ProfilerClient(BaseClient):
 
     def list_columns(
         self, workspace_id: str, source_uuid: str, table_uuid: str
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """
         Get all columns in a table
 

--- a/lightctl/client/source_client.py
+++ b/lightctl/client/source_client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict, List
 from uuid import UUID
 
 from lightctl.client.base_client import BaseClient
@@ -19,6 +18,7 @@ class SourceClient(BaseClient):
         for datasource in datasource_list:
             print("Datasource {datasource["name"]})
     """
+
     def sources_url(self, workspace_id: str) -> str:
         """
         Returns:
@@ -28,7 +28,7 @@ class SourceClient(BaseClient):
             self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/sources/"
         )
 
-    def list_sources(self, workspace_id: str) -> List[Dict]:
+    def list_sources(self, workspace_id: str) -> list[dict]:
         """
         Get all datasources in the workspace
 
@@ -40,7 +40,7 @@ class SourceClient(BaseClient):
         """
         return self.get(self.sources_url(workspace_id))
 
-    def get_source(self, workspace_id: str, id: UUID) -> Dict:
+    def get_source(self, workspace_id: str, id: UUID) -> dict:
         """
         Get a datasources by its uuid
 
@@ -54,7 +54,7 @@ class SourceClient(BaseClient):
         url = urllib.parse.urljoin(self.sources_url(workspace_id), f"{id}")
         return self.get(url)
 
-    def get_source_by_name(self, workspace_id: str, name: str) -> List[Dict]:
+    def get_source_by_name(self, workspace_id: str, name: str) -> list[dict]:
         """
         Get a datasource by its name
 
@@ -72,7 +72,7 @@ class SourceClient(BaseClient):
                 ret_sources.append(source)
         return ret_sources
 
-    def create_source(self, workspace_id: str, data: Dict) -> Dict:
+    def create_source(self, workspace_id: str, data: dict) -> dict:
         """
         Create a datasource
 
@@ -85,7 +85,7 @@ class SourceClient(BaseClient):
         """
         return self.post(self.sources_url(workspace_id), data)
 
-    def update_source(self, workspace_id: str, id: UUID, data: Dict) -> Dict:
+    def update_source(self, workspace_id: str, id: UUID, data: dict) -> dict:
         """
         Update a datasource
 
@@ -100,7 +100,7 @@ class SourceClient(BaseClient):
         url = urllib.parse.urljoin(self.sources_url(workspace_id), f"{id}")
         return self.put(url, data)
 
-    def delete_source(self, workspace_id: str, id: UUID) -> Dict:
+    def delete_source(self, workspace_id: str, id: UUID) -> dict:
         """
         Delete a datasource
 
@@ -111,13 +111,13 @@ class SourceClient(BaseClient):
         """
         self.delete(self.sources_url(workspace_id), f"{id}")
 
-    def inspect(self, workspace_id: str, data: Dict) -> Dict:
+    def inspect(self, workspace_id: str, data: dict) -> dict:
         url = urllib.parse.urljoin(
             self.sources_url(workspace_id), "/sources/inspection"
         )
         return self.post(url, data, expected_status=200)
 
-    def list_columns(self, workspace_id: str, id: UUID, table_id: UUID) -> List[Dict]:
+    def list_columns(self, workspace_id: str, id: UUID, table_id: UUID) -> list[dict]:
         """
         Get all columns in a table
 
@@ -137,7 +137,7 @@ class SourceClient(BaseClient):
 
     def get_column(
         self, workspace_id: str, id: UUID, table_id: UUID, column_id: UUID
-    ) -> Dict:
+    ) -> dict:
         """
         Get a column from its column_id
 
@@ -150,7 +150,7 @@ class SourceClient(BaseClient):
         Returns:
             dict: a column
         """
-        
+
         url = urllib.parse.urljoin(
             self.sources_url(workspace_id),
             f"{id}/profile/tables/{table_id}/columns/{column_id}",
@@ -158,7 +158,7 @@ class SourceClient(BaseClient):
         column = self.get(url)
         return column
 
-    def list_tables(self, workspace_id: str, id: UUID) -> List[Dict]:
+    def list_tables(self, workspace_id: str, id: UUID) -> list[dict]:
         """
         Get all tables in a datasource
 
@@ -175,7 +175,7 @@ class SourceClient(BaseClient):
         tables = self.get(url)
         return tables["data"]
 
-    def get_table(self, workspace_id: str, id: UUID, table_id: UUID) -> Dict:
+    def get_table(self, workspace_id: str, id: UUID, table_id: UUID) -> dict:
         """
         Get a table from its table id
 
@@ -193,7 +193,7 @@ class SourceClient(BaseClient):
         table = self.get(url)
         return table
 
-    def get_table_schema(self, workspace_id: str, id: UUID, table_name: str) -> Dict:
+    def get_table_schema(self, workspace_id: str, id: UUID, table_name: str) -> dict:
         """
         Get a table's schema by table name
 
@@ -211,7 +211,7 @@ class SourceClient(BaseClient):
         )
         return self.get(url)
 
-    def list_schemas(self, workspace_id: str, id: UUID) -> List[Dict]:
+    def list_schemas(self, workspace_id: str, id: UUID) -> list[dict]:
         """
         Get all schemas in the datasource
 
@@ -228,7 +228,7 @@ class SourceClient(BaseClient):
         schemas = self.get(url)
         return schemas["data"]
 
-    def get_schema(self, workspace_id: str, id: UUID, schema_id: UUID) -> Dict:
+    def get_schema(self, workspace_id: str, id: UUID, schema_id: UUID) -> dict:
         """
         Get a schema from its schema id
 
@@ -247,8 +247,8 @@ class SourceClient(BaseClient):
         return schema
 
     def update_profiler_config(
-        self, workspace_id: str, id: UUID, table_uuid: str, data: Dict
-    ) -> Dict:
+        self, workspace_id: str, id: UUID, table_uuid: str, data: dict
+    ) -> dict:
         """
         Update configuration for a table in a datasource
 
@@ -265,7 +265,7 @@ class SourceClient(BaseClient):
         )
         return self.put(url, data)
 
-    def trigger_source(self, workspace_id: str, id: UUID, data: Dict) -> Dict:
+    def trigger_source(self, workspace_id: str, id: UUID, data: dict) -> dict:
         """
         Trigger data collection on all triggered metrics in a datasource
 

--- a/lightctl/client/user_client.py
+++ b/lightctl/client/user_client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict, List
 
 from lightctl.client.base_client import BaseClient
 
@@ -28,7 +27,7 @@ class UserClient(BaseClient):
         """
         return urllib.parse.urljoin(self.url_base, "/api/v0/users/")
 
-    def add_app_user(self, username: str, role: str) -> Dict:
+    def add_app_user(self, username: str, role: str) -> dict:
         """
         Add a user to the app
 
@@ -101,7 +100,7 @@ class UserClient(BaseClient):
         url = urllib.parse.urljoin(self.app_users_url(), quoted_user)
         return self.get(url)
 
-    def list_app_users(self) -> List[Dict]:
+    def list_app_users(self) -> list[dict]:
         """
         Get all users in the app
 
@@ -123,7 +122,7 @@ class UserClient(BaseClient):
 
     def add_user_to_workspace(
         self, workspace_id: str, username: str, role: str
-    ) -> Dict:
+    ) -> dict:
         """
         Add a user to a workspace
 
@@ -140,7 +139,7 @@ class UserClient(BaseClient):
         res = self.post(url, payload)
         return res
 
-    def remove_user_from_workspace(self, workspace_id: str, username: str) -> Dict:
+    def remove_user_from_workspace(self, workspace_id: str, username: str) -> dict:
         """
         Remove user from a workspace
 
@@ -169,7 +168,7 @@ class UserClient(BaseClient):
         payload = {"role": role}
         return self.patch(url, payload)
 
-    def list_users(self, workspace_id: str) -> List[Dict]:
+    def list_users(self, workspace_id: str) -> list[dict]:
         """
         Get all users in the workspace
 

--- a/lightctl/client/workspace_client.py
+++ b/lightctl/client/workspace_client.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from typing import Dict, List
 
 from lightctl.client.base_client import BaseClient
 
@@ -13,15 +12,16 @@ class WorkspaceClient(BaseClient):
 
     Example:
       wc = WorkspaceClient()
-      workspaces = wc.list_workspaces() 
+      workspaces = wc.list_workspaces()
       new_workspace = wc.create_workspace("test_workspace")
     """
+
     def workspaces_url(self) -> str:
         """
         Returns:
            str: The workspaces endpoint, used for getting existing workspaces, creating new workspaces, and deleting workspaces
         """
-        return urllib.parse.urljoin(self.url_base, f"/api/v1/workspaces/")
+        return urllib.parse.urljoin(self.url_base, "/api/v1/workspaces/")
 
     def create_workspace(self, name: str):
         """
@@ -30,7 +30,7 @@ class WorkspaceClient(BaseClient):
         Args:
             name (str): Name of workspace
 
-        Returns: 
+        Returns:
             dict: The workspace created
 
         Example:
@@ -43,21 +43,21 @@ class WorkspaceClient(BaseClient):
         res = self.post(url, payload)
         return res["data"]
 
-    def delete_workspace(self, workspace_id: str) -> Dict:
+    def delete_workspace(self, workspace_id: str) -> dict:
         """
         Delete a workspace
 
         Args:
             workspace_id (str): UUID of workspace
 
-        Returns: 
+        Returns:
             str: The uuid of the workspace deleted
         """
         # note that delete workspace is associated with different url.
         url = urllib.parse.urljoin(self.url_base, "/api/v1/ws/")
         return self.delete(url, workspace_id, force=True)
 
-    def list_workspaces(self) -> List[Dict]:
+    def list_workspaces(self) -> list[dict]:
         """
         Get all workspaces
 

--- a/lightctl/config.py
+++ b/lightctl/config.py
@@ -5,7 +5,7 @@ API_VERSION = "v1"
 
 ACCESS_TOKEN_CACHE_FILE_PATH = os.environ.get(
     "CACHED_CREDENTIAL_PATH",
-    os.path.join(str(Path.home()), ".lightup", ".access-token-cache")
+    os.path.join(str(Path.home()), ".lightup", ".access-token-cache"),
 )
 
 CREDENTIAL_FILE_PATH = os.environ.get(


### PR DESCRIPTION
Updated pre-commit configuration to match the current python version and executed the following command to reformat the current codebase: 

`pre-commit run -a`

These changes are all cosmetic and changes to match python 3.9 style.