### PR TITLE
metric: support preview

### DIFF
--- a/lightctl/client/metric_client.py
+++ b/lightctl/client/metric_client.py
@@ -32,6 +32,15 @@ class MetricClient(BaseClient):
             self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/metrics/"
         )
 
+    def metrics_preview_url(self, workspace_id: str) -> str:
+        """
+        Returns:
+           str: The metrics endpoint, used for getting and modifying metrics
+        """
+        return urllib.parse.urljoin(
+            self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/metrics/preview"
+        )
+
     def list_metrics(self, workspace_id: str) -> list[dict]:
         """
         Get all metrics in the workspace
@@ -84,6 +93,21 @@ class MetricClient(BaseClient):
             dict: the metric created
         """
         return self.post(self.metrics_url(workspace_id), data)
+
+    def preview_metric(self, workspace_id: str, data: dict) -> dict:
+        """
+        preview a metric
+
+        Args:
+            workspace_id (str): Workspace id
+            data (dict) attributes of metric
+
+        Returns:
+            dict: the metric created
+        """
+        return self.post(
+            self.metrics_preview_url(workspace_id), data, expected_status=200
+        )
 
     def update_metric(
         self, workspace_id: str, id: UUID, data: dict, force: bool = False

--- a/lightctl/client/metric_client.py
+++ b/lightctl/client/metric_client.py
@@ -35,7 +35,7 @@ class MetricClient(BaseClient):
     def metrics_preview_url(self, workspace_id: str) -> str:
         """
         Returns:
-           str: The metrics endpoint, used for getting and modifying metrics
+           str: The metrics preview endpoint, used for previewing metrics
         """
         return urllib.parse.urljoin(
             self.url_base, f"/api/{API_VERSION}/ws/{workspace_id}/metrics/preview"

--- a/lightctl/command/metric_command.py
+++ b/lightctl/command/metric_command.py
@@ -103,7 +103,7 @@ def get_table_samples(context_obj, file):
 @click.pass_obj
 def preview(context_obj, file):
     """
-    preview  metric from yaml or json file
+    Preview metric from YAML or JSON file
     """
     data = context_obj.file_loader.load(file)
     res = metric_client.preview_metric(context_obj.workspace_id, data)

--- a/lightctl/command/metric_command.py
+++ b/lightctl/command/metric_command.py
@@ -96,3 +96,15 @@ def get_table_samples(context_obj, file):
     data = context_obj.file_loader.load(file)
     res = metric_client.get_table_samples(context_obj.workspace_id, data)
     context_obj.printer.print(res)
+
+
+@metric.command()
+@click.argument("file", type=click.Path(exists=True))
+@click.pass_obj
+def preview(context_obj, file):
+    """
+    preview  metric from yaml or json file
+    """
+    data = context_obj.file_loader.load(file)
+    res = metric_client.preview_metric(context_obj.workspace_id, data)
+    context_obj.printer.print(res)


### PR DESCRIPTION
This pull request introduces functionality for previewing metrics in the `lightctl` client and command-line tool. The most important changes include adding a new method to generate preview URLs, implementing a method to preview metrics via the API, and creating a CLI command to utilize this functionality.

### Additions to the `lightctl` client:

* **New URL generation method**: Added `metrics_preview_url` method to generate the endpoint for previewing metrics.
* **New API method**: Added `preview_metric` method to send a POST request to the preview endpoint, allowing users to preview metrics before finalizing them.

### Enhancements to the CLI:

* **New CLI command**: Added a `preview` command to the `metric` group, enabling users to preview metrics from a YAML or JSON file via the command-line interface.